### PR TITLE
fix when follow user

### DIFF
--- a/lib/page/profile/profilePage.dart
+++ b/lib/page/profile/profilePage.dart
@@ -262,7 +262,7 @@ class _ProfilePageState extends State<ProfilePage>
   }
 
   isFollower() {
-    var authstate = Provider.of<AuthState>(context);
+    var authstate = Provider.of<AuthState>(context, listen: false);
     if (authstate.profileUserModel.followersList != null &&
         authstate.profileUserModel.followersList.isNotEmpty) {
       return (authstate.profileUserModel.followersList


### PR DESCRIPTION
When I try to click follow button, get this error:
The following assertion was thrown while handling a gesture:
Tried to listen to a value exposed with provider, from outside of the widget tree.

This is likely caused by an event handler (like a button's onPressed) that called
Provider.of without passing `listen: false`.

To fix, write:
Provider.of<AuthState>(context, listen: false);
